### PR TITLE
kex: allow SNTRU-Prime

### DIFF
--- a/sshd_config
+++ b/sshd_config
@@ -98,7 +98,7 @@ PubkeyAuthentication yes
 # explicitly define cryptography algorithms to avoid the use of weak algorithms
 # AES CTR modes have been removed to mitigate the Terrapin attack
 #   https://terrapin-attack.com/
-Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com
+Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com
 HostKeyAlgorithms rsa-sha2-512,rsa-sha2-256,ssh-ed25519
 MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
 

--- a/sshd_config
+++ b/sshd_config
@@ -98,7 +98,7 @@ PubkeyAuthentication yes
 # explicitly define cryptography algorithms to avoid the use of weak algorithms
 # AES CTR modes have been removed to mitigate the Terrapin attack
 #   https://terrapin-attack.com/
-Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com
+Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com
 HostKeyAlgorithms rsa-sha2-512,rsa-sha2-256,ssh-ed25519
 MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
 

--- a/sshd_config
+++ b/sshd_config
@@ -105,7 +105,7 @@ MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@op
 # short moduli should be deactivated before enabling the use of diffie-hellman-group-exchange-sha256
 # see this link for more details: https://github.com/k4yt3x/sshd_config#deactivating-short-diffie-hellman-moduli
 #KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256
-KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
 
 ########## Connection Preferences ##########
 

--- a/sshd_config
+++ b/sshd_config
@@ -1,7 +1,9 @@
 # Name: K4YT3X Hardened OpenSSH Configuration
 # Author: K4YT3X
+# Contributor: IceCodeNew
+# Contributor: brxken128
 # Date Created: October 5, 2020
-# Last Updated: January 12, 2024
+# Last Updated: February 8, 2024
 
 # Licensed under the GNU General Public License Version 3 (GNU GPL v3),
 #   available at: https://www.gnu.org/licenses/gpl-3.0.txt
@@ -103,9 +105,10 @@ HostKeyAlgorithms rsa-sha2-512,rsa-sha2-256,ssh-ed25519
 MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
 
 # short moduli should be deactivated before enabling the use of diffie-hellman-group-exchange-sha256
-# see this link for more details: https://github.com/k4yt3x/sshd_config#deactivating-short-diffie-hellman-moduli
-#KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256
-KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+#   see this link for more details: https://github.com/k4yt3x/sshd_config#deactivating-short-diffie-hellman-moduli
+# Chacha20-Poly1305 has been removed to mitigate the Terrapin attack: https://terrapin-attack.com/
+# ecdh-sha2-nistp* algorithms have been removed due to concerns around NIST P-curves' design: https://github.com/jtesta/ssh-audit/issues/213#issuecomment-1774204745
+KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group18-sha512,diffie-hellman-group16-sha512
 
 ########## Connection Preferences ##########
 

--- a/sshd_config
+++ b/sshd_config
@@ -1,7 +1,7 @@
 # Name: K4YT3X Hardened OpenSSH Configuration
 # Author: K4YT3X
 # Date Created: October 5, 2020
-# Last Updated: December 21, 2023
+# Last Updated: January 12, 2024
 
 # Licensed under the GNU General Public License Version 3 (GNU GPL v3),
 #   available at: https://www.gnu.org/licenses/gpl-3.0.txt

--- a/sshd_config
+++ b/sshd_config
@@ -5,7 +5,7 @@
 
 # Licensed under the GNU General Public License Version 3 (GNU GPL v3),
 #   available at: https://www.gnu.org/licenses/gpl-3.0.txt
-# (C) 2020-2023 K4YT3X
+# (C) 2020-2024 K4YT3X
 
 ########## Binding ##########
 


### PR DESCRIPTION
This PR adds the SNTRU-Prime key exchange, and adds ChaCha20-Poly1305 back as a symmetric algorithm.

#7 (arguably incorrectly) removed ChaCha20-Poly1305 from the approved ciphers. It is an AEAD, similar in function to AES-GCM, however it is likely more secure in the grand scheme of things and isn't vulnerable to the Terrapin attack. [This blog post](https://soatok.blog/2020/05/13/why-aes-gcm-sucks/) mentions some of the shortcomings of AES-GCM, but more importantly highlights some of the benefits for (X)ChaCha20-Poly1305. XChaCha has the advantage of a 192-bit nonce, but the base ChaCha is not too far off.

SNTRU-Prime is a lattice-based post-quantum key exchange and aims to patch some of the shortcomings with current key exchanges, going into the post-quantum era. In the OpenSSH implementation, it's used in hybrid mode with x25519 - this way, if one fails (whether that's SNTRU-Prime or x25519), the other will likely still hold up.