### PR TITLE
Disable User Environment Variables Passthrough

### DIFF
--- a/sshd_config
+++ b/sshd_config
@@ -162,3 +162,7 @@ TCPKeepAlive no
 
 # disable reverse DNS lookups
 UseDNS no
+
+# anything the user could accomplish with environment variables could also do interactively in their shell. 
+# disabling the passing of environment variables could reduce/minimize a potential attack vector 
+PermitUserEnvironment no

--- a/sshd_config
+++ b/sshd_config
@@ -31,6 +31,9 @@ AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
 AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
 AcceptEnv XMODIFIERS
 
+# disallow automatically setting environment variables through ~/.ssh/environment
+PermitUserEnvironment no
+
 # disallow ssh-agent forwarding to prevent lateral movement
 AllowAgentForwarding no
 
@@ -162,7 +165,3 @@ TCPKeepAlive no
 
 # disable reverse DNS lookups
 UseDNS no
-
-# anything the user could accomplish with environment variables could also do interactively in their shell. 
-# disabling the passing of environment variables could reduce/minimize a potential attack vector 
-PermitUserEnvironment no


### PR DESCRIPTION
I am perplexed and hesitant on this pull request.
My scenario calls for the prevention of users from setting environment variables. `PermitUserEnvironment no` is not present in this hardened configuration. Looking further into the [man pages](https://www.man7.org/linux/man-pages/man5/sshd_config.5.html), it says the following:

```
Valid options are yes, no or a pattern-list
specifying which environment variable names to accept
(for example "LANG,LC_*").  The default is no.  Enabling
environment processing may enable users to bypass access
restrictions in some configurations using mechanisms such
as LD_PRELOAD.
```
With my interpretation of this, it seems like accepting _specific_ environment variables - which is already set in the latest commit - automatically disables `PermitUserEnvironment` 

```
AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
AcceptEnv XMODIFIERS
```
However, stigs/articles like the following seem like `PermitUserEnvironment no` should be configured to eliminate a potential attack vector.
https://www.stigviewer.com/stig/red_hat_enterprise_linux_8/2021-03-04/finding/V-230330#:~:text=Configure%20RHEL%208%20to%20allow%20the%20SSH%20daemon%20to%20not
https://serverfault.com/questions/527638/security-risks-of-permituserenvironment-in-ssh#:~:text=Enabling%20environment%20processing%20may%20enable%20users%20to%20bypass%20access%20restrictions


Please let me know if there is a reason for not having `PermitUserEnvironment no` and just allowing specific environment variables. 